### PR TITLE
Terraform refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+_answer.tf
+
 # Local .terraform directories
 **/.terraform*
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-_answer.tf
+*_answer.tf
 
 # Local .terraform directories
 **/.terraform*

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     less \
     openssh-client \
+    parallel \
     sudo \
     unzip
 WORKDIR /tmp
@@ -37,7 +38,7 @@ COPY files/hashi.asc /tmp/hashi.asc
 RUN ./install-terraform.sh
 COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
 COPY scripts/test.sh /test/test.sh
-COPY scripts/load.bash /test/load.bash
+COPY scripts/*.bash /test/
 RUN useradd -ms /bin/bash -G sudo me && \
     echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 

--- a/challenges/terraform/01-hello-terraform/README.md
+++ b/challenges/terraform/01-hello-terraform/README.md
@@ -7,9 +7,9 @@ Difficulty: *Beginner*
 ## :pencil: Prerequisite Knowledge
 
 **beginner**
-- what is terraform
-- what is aws cloud
-- what is a virtual machine
+- terraform
+- AWS cloud
+- virtual machines
 
 ## :books: Resources
 

--- a/challenges/terraform/01-hello-terraform/README.md
+++ b/challenges/terraform/01-hello-terraform/README.md
@@ -1,29 +1,43 @@
 # 01-hello-terraform
 
-1. Using terraform, configure an AWS EC2 instance tagged with a name of "hello-terraform".
-2. Output the EC2 instance ID as a terraform output named `instance_id`
+Difficulty: *Beginner*
 
-## Resources
+1. Using terraform, configure an AWS EC2 instance tagged with a name of "hello-terraform".
+
+## :pencil: Prerequisite Knowledge
+
+**beginner**
+- what is terraform
+- what is aws cloud
+- what is a virtual machine
+
+## :books: Resources
 
 ### EC2
 
-- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html
+- EC2 Concepts
+  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html
+- Tagging AWS Resources
+  https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
 
 ### terraform
 
-- Get started with terraform. The `docker compose run shell` environment is already configured with AWS credentials and has `terraform` and `aws` installed. A `provider.tf` is already configured for the local AWS environment and does not need modification.
-https://learn.hashicorp.com/tutorials/terraform/aws-build?in=terraform/aws-get-started
+- The `docker compose run shell` environment is already configured with AWS credentials and has `terraform` and `aws` installed. A `provider.tf` is already configured for the local AWS environment and does not need modification. **NOTE:** The `provider.tf` in this environment is not configured like you would normally see in a production environment, it's specifically set up for the local AWS environment.
+- Get started with terraform
+  https://learn.hashicorp.com/tutorials/terraform/aws-build?in=terraform/aws-get-started
 
-- How to create an EC2 instance with terraform. 
-https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
-
-- terraform outputs 
-https://www.terraform.io/docs/language/values/outputs.html
+- Create an EC2 instance with terraform
+  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
 
 **NOTE:** Using a data lookup to find an AMI will not work in this environment. You can use any AMI id.
 
-## Test your  work
+## :white_check_mark: Test your work
+
+- Add terraform code to `main.tf` 
+- Run `terraform init`, `terraform plan`, and `terraform apply` commands to apply your terraform code to create the EC2 instance.
+- Check that your solution meets all requirements by running
 
 ```
-bats test.bats
+./test.sh
 ```
+

--- a/challenges/terraform/01-hello-terraform/test.bats
+++ b/challenges/terraform/01-hello-terraform/test.bats
@@ -1,20 +1,41 @@
 function setup_file() {
     set +e
+    load '/test/setup_terraform.bash'
+
+    # apply terraform
     terraform init
     terraform apply -input=false -auto-approve -lock=false    
     set -e
 }
 
-setup() {
+function setup() {
+    # fail-fast
+    [ ! -f ${BATS_PARENT_TMPNAME}.skip ] || skip "skip remaining tests"
+
     load '/test/bats-support/load.bash'
     load '/test/bats-assert/load.bash'
     load '/test/load.bash'
+    cd /tmp/test-terraform
 }
 
-@test "EC2 instance exists with name tag 'hello-terraform'" {
-    ID=$(terraform output -raw instance_id) 
-    run aws ec2 describe-instances --instance-ids $ID
+AWS="/usr/local/bin/aws --endpoint-url http://moto-test:5000"
+
+@test "EC2 instance exists" {
+    COMMAND="$AWS ec2 describe-instances --filters Name=instance-state-name,Values='running'"
+    run eval "$COMMAND"
+    printf "\n\nERROR: No running EC2 instance found using command:\n $COMMAND\n\n"
+    assert_output --partial "InstanceId"
+}
+
+@test "EC2 instance is tagged with 'hello-terraform'" {
+    COMMAND="$AWS ec2 describe-instances --filters 'Name=tag-value,Values=hello-terraform'"
+    run eval "$COMMAND"
+    printf "\n\nERROR: No EC2 instance found with tag 'hello-terraform' using command:\n $COMMAND\n\n"
     assert_output --partial 'hello-terraform'
+}
+
+function teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch ${BATS_PARENT_TMPNAME}.skip
 }
 
 function teardown_file() {

--- a/challenges/terraform/01-hello-terraform/test.sh
+++ b/challenges/terraform/01-hello-terraform/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Setting up terraform, this may take a moment..."
+bats test.bats

--- a/challenges/terraform/02-basic-vpc/README.md
+++ b/challenges/terraform/02-basic-vpc/README.md
@@ -1,18 +1,32 @@
 # 02-basic-vpc
 
+Difficulty: *Beginner*
+
 1. Using terraform, configure an AWS VPC with a CIDR of 172.16.0.0/16.
 2. Output the VPC ID as a terraform output named `vpc_id`
 
-## Resources
+## :pencil: Prerequisite Knowledge
 
-### VPC 
+**beginner**
+- terraform
+- networking
 
-- https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
+## :books: Resources
+
+### VPC
+
+- VPC Basics
+  https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
 - VPC Networking
-https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html
+  https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html
 
-## Test your  work
+### terraform
+
+- terraform outputs
+  https://www.terraform.io/docs/language/values/outputs.html
+
+## :white_check_mark: Test your work
 
 ```
-bats test.bats
+./test.sh
 ```

--- a/challenges/terraform/02-basic-vpc/test.bats
+++ b/challenges/terraform/02-basic-vpc/test.bats
@@ -1,22 +1,42 @@
 function setup_file() {
     set +e
+    load '/test/setup_terraform.bash'
+
+    # apply terraform
     terraform init
     terraform apply -input=false -auto-approve -lock=false    
     set -e
 }
 
-setup() {
+function setup() {
+    # fail-fast
+    [ ! -f ${BATS_PARENT_TMPNAME}.skip ] || skip "skip remaining tests"
+
     load '/test/bats-support/load.bash'
     load '/test/bats-assert/load.bash'
     load '/test/load.bash'
+    cd /tmp/test-terraform
+}
+
+AWS="/usr/local/bin/aws --endpoint-url http://moto-test:5000"
+
+@test "terraform output 'vpc_id' is configured" {
+    run terraform output vpc_id
+    assert_output --partial "vpc"
 }
 
 @test "VPC is configured with a CIDR block of 172.16.0.0/16" {
-    ID=$(terraform output -raw vpc_id) 
-    run aws ec2 describe-vpcs --vpc-ids $ID --query "Vpcs[*].CidrBlock" --output text
+    ID=$(terraform output --raw vpc_id) 
+    COMMAND="$AWS ec2 describe-vpcs --vpc-ids $ID --query 'Vpcs[*].CidrBlock' --output text"
+    run eval "$COMMAND"
+    printf "\n\nERROR: No VPC found using command:\n $COMMAND\n\n"
     assert_output "172.16.0.0/16"
 }
 
+function teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch ${BATS_PARENT_TMPNAME}.skip
+}
+
 function teardown_file() {
-    terraform destroy -auto-approve -input=false -lock=false    
+    terraform destroy -auto-approve -input=false -lock=false
 }

--- a/challenges/terraform/02-basic-vpc/test.sh
+++ b/challenges/terraform/02-basic-vpc/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Setting up terraform, this may take a moment..."
+bats test.bats

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3.8"
 
 services:
-  moto:
+  moto: &moto-config
     # v2.0.8
     image: motoserver/moto@sha256:f3785700783a3ccf0c57c589ab06cf2ce3dcbf72961295d5d04686f62e6181ba
+  moto-test:
+    <<: *moto-config
 
   shell:
     build:
@@ -16,6 +18,7 @@ services:
         - BATS_ASSERT_VER=672ad18
     depends_on: 
       - moto
+      - moto-test
     hostname: docker-challenges
     environment: 
       - AWS_DEFAULT_REGION=us-east-1

--- a/scripts/setup_terraform.bash
+++ b/scripts/setup_terraform.bash
@@ -1,0 +1,8 @@
+# work from a clean tf directory (no state)
+rm -rf /tmp/test-terraform
+mkdir /tmp/test-terraform
+cp ./*.tf /tmp/test-terraform
+cd /tmp/test-terraform
+# use test AWS
+cp /challenges/terraform/provider.tf provider.tf
+sed -i 's/moto/moto-test/g' provider.tf


### PR DESCRIPTION
- updates the gitignore to support keeping local answer files locally
- refactors challenge readmes
    - adds difficulty level
    - explains the terraform provider.tf is not normal (Closes #12)
-  wraps the bats test in a script to allow messaging that initial terraform setup is slow (Closes #10)
- runs terraform tests against a separate moto-test server and from a clean directory to test terraform from a clean starting point while not interfering with the regular challenge aws environment state
- bats tests fail on the first error (fail fast) (Closes #16)